### PR TITLE
chore: adopt shared Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>privacykey/renovate-config"]
+}


### PR DESCRIPTION
## What changed
- Added a root `renovate.json` extending the shared preset [privacykey/renovate-config](https://github.com/privacykey/renovate-config).
- No existing Renovate or Dependabot config was present, so nothing was removed.
- Deprecated workflow actions are deliberately untouched here; a separate hygiene PR will handle those.

## Activation
Renovate runs via the hosted Mend Renovate GitHub App. The App install is still pending, so this PR is inert until then.

## What the preset means
- One grouped non-major update PR each Monday (Australia/Melbourne time).
- Major updates are held on the Dependency Dashboard for manual approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)