### PR TITLE
chore: comment cleanup in sync-website.yml

### DIFF
--- a/.github/workflows/sync-website.yml
+++ b/.github/workflows/sync-website.yml
@@ -28,6 +28,5 @@ jobs:
           # authenticates with the checkout's GITHUB_TOKEN.
       - name: Push main to gh-pages
         # gh-pages mirrors main for awesome-aussie.com. --force is required
-        # because the old PR-based sync left merge commits on gh-pages that
-        # main does not have.
+        # because gh-pages carries commits that main does not have.
         run: git push --force origin main:gh-pages


### PR DESCRIPTION
One-line follow-up to #142: the force-push comment now states the constraint (gh-pages has commits main doesn't) without narrating the previous sync mechanism. Comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)