### PR TITLE
chore: add justfile with pnpm task recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,19 @@
+# List available commands
+default:
+    @just --list
+
+# Install dependencies with pnpm (frozen lockfile, matching CI)
+[group("dev")]
+setup:
+    pnpm install --frozen-lockfile
+
+# Rebuild README.md and EXTENDED.md from Airtable (needs AIRTABLE_API_KEY + AIRTABLE_BASE_ID)
+[group("ship")]
+build:
+    pnpm run readme
+    pnpm run extended
+
+# Sync GitHub issues to Airtable (needs Airtable secrets + GH_API_TOKEN)
+[group("ship")]
+issues:
+    pnpm run issues


### PR DESCRIPTION
Adds a root `justfile` following the portfolio convention. Recipes delegate to the repo's real pnpm scripts (per `package.json` and the `readme.yml` / `issues.yml` workflows). The existing CC0 license is untouched.

Verified locally with `just --list`:

```
Available recipes:
    default # List available commands

    [dev]
    setup   # Install dependencies with pnpm (frozen lockfile, matching CI)

    [ship]
    build   # Rebuild README.md and EXTENDED.md from Airtable (needs AIRTABLE_API_KEY + AIRTABLE_BASE_ID)
    issues  # Sync GitHub issues to Airtable (needs Airtable secrets + GH_API_TOKEN)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
